### PR TITLE
Fix type definition for the security field in openapi documents

### DIFF
--- a/src/open_api/document.cr
+++ b/src/open_api/document.cr
@@ -14,7 +14,7 @@ module OpenAPI
     field servers : Array(Server)?
     field paths : Hash(String, PathItem) = Hash(String, PathItem).new
     field components : Components = Components.new
-    field security : Hash(String, Array(String))?
+    field security : Array(Hash(String, Array(String)))?
     field tags : Array(Tag)?
     field external_docs : ExternalDocumentation?
   end


### PR DESCRIPTION
Hey there!

The `security` field on an openapi document has the type `Array(Hash(String, Array(String)))?`

This was correct in `src/open_api/operation.cr` but incorrect in `src/open_api/document.cr`.

This patch brings it in line with the definition used in the openapi docs.