### PR TITLE
camelize keys when generating yaml file

### DIFF
--- a/src/open_api/object.cr
+++ b/src/open_api/object.cr
@@ -47,6 +47,7 @@ module OpenAPI
         field({{ name }} : {{ union_types.reduce([] of AstNode) { |types, type| types + (type.is_a?(Union) ? type.types : [type]) }.join(" | ").id }})
       {% else %}
         {% if name =~ /_/ %}
+          @[YAML::Field(key: {{ "#{name[0...1]}#{name.camelcase[1..-1]}" }})]
           @[JSON::Field(key: {{ "#{name[0...1]}#{name.camelcase[1..-1]}" }})]
         {% end %}
         getter {{ type_declaration }}


### PR DESCRIPTION
First, I'd like to say thanks for this great lib ❤️.

I just noticed that when generating a `yaml` openapi file the keys were not camelized (for `json` it seems to be allright). Adding a `@YAML::Field[…]` annotation should fix it.