### PR TITLE
add readOnly and writeOnly schema fields

### DIFF
--- a/src/open_api/schema.cr
+++ b/src/open_api/schema.cr
@@ -32,5 +32,7 @@ module OpenAPI
     field description : String?
     field format : String?
     field default : JSON::Any::Type
+    field read_only : Bool?
+    field write_only : Bool?
   end
 end


### PR DESCRIPTION
#### Adds the [readOnly and writeOnly](https://github.com/OAI/OpenAPI-Specification/blob/1bb2c2879730fdea4dd98c6ae72e6368fd1023a0/schemas/v3.0/schema.yaml#L317) properties to the `Schema` class.

[Here](https://swagger.io/docs/specification/data-models/data-types/#readonly-writeonly) is a detailed explanation of the fields.
